### PR TITLE
fix: import namespace specifier support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fix import decls should not be removed
+
+## 0.1.8
+
+### Fixed
+
+- Import namespace specifier support

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-modules-to-tailwind",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "tailwind css convert tool",
   "contributors": [
     "shiyangzhaoa"

--- a/src/get-tailwind-map.ts
+++ b/src/get-tailwind-map.ts
@@ -31,22 +31,28 @@ export const getTailwindMap = async (
     cssImportSpecifiers.forEach((path) => {
       const importDecl = j(path);
 
+      // import style from 'index.module.css';
       const importDefaultSpecifiers = importDecl
         .find(j.ImportDefaultSpecifier)
         .find(j.Identifier);
-      const importDefaultNodes = importDefaultSpecifiers.nodes();
+      // import * as style from 'index.module.css';
+      const importNamespaceSpecifiers = importDecl
+        .find(j.ImportNamespaceSpecifier)
+        .find(j.Identifier);
+        
+      const importCSSNodes = [...importDefaultSpecifiers.nodes(), ...importNamespaceSpecifiers.nodes()];
 
-      if (importDefaultNodes.length === 0) return;
+      if (importCSSNodes.length === 0) return;
 
-      const importDefaultNode = importDefaultNodes[0];
-      const importDefaultName = importDefaultNode.name;
+      const importCSSNode = importCSSNodes[0];
+      const importCSSName = importCSSNode.name;
 
       const sourcePath = importDecl.find(j.Literal).get().node;
       const cssSourcePath = sourcePath.value;
       const cssPath = getCompletionEntries(dir)(cssSourcePath);
 
       promises.push({
-        key: importDefaultName,
+        key: importCSSName,
         value: cssToTailwind(cssPath),
       });
     });


### PR DESCRIPTION
Fix https://github.com/shiyangzhaoa/css-modules-to-tailwind/issues/1

Import namespace specifier ruler support:

```js
import * as style from 'index.module.css';
```