### PR TITLE
fix: Class substitution rules update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,3 +70,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Keep useful `className`
+
+## 0.2.1
+
+### Fixed
+
+- Fix `className` substitution rules

--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ Try it yourself:
          <img className='h-2.5 w-2.5' alt="avatar" />
          <span className='text-sky-300 text-xs ml-1'>username</span>
        </div>
-       <div className={'invalid-class'}>name</div>
+       <div className={` `}>name</div>
      </div>
    );
    ```
 
-   > If the css file content is empty, import specifiers and css files will be removed, unused class will be replaced with 'invalid-class'.
+   > If the css file content is empty, import specifiers and css files will be removed, unused class will be replaced with \` \`, You should search globally for \` \`, then delete them.
 
 🙋‍♂️ Flat and single structure design makes this tool work better.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-modules-to-tailwind",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "tailwind css convert tool",
   "contributors": [
     "shiyangzhaoa"

--- a/src/fill-tailwind-class.ts
+++ b/src/fill-tailwind-class.ts
@@ -80,12 +80,14 @@ export const fillTailwindClass = (
 
             return;
           }
-        }
 
-        if (isUnlinked) {
-          styleMemberExpression.replace(j.literal('invalid-class'));
+          try {
+            styleMemberExpression.replace(j.literal(className));
 
-          return;
+            return;
+          } catch {
+            //
+          }
         }
 
         const quasis = [
@@ -95,7 +97,8 @@ export const fillTailwindClass = (
             true,
           ),
         ];
-        const expressions = [
+
+        const expressions = (isUnlinked || isRemoved) ? [] : [
           j.memberExpression(
             j.identifier(object.name),
             j.identifier(validName),


### PR DESCRIPTION
```css
.valid {
   display: flex;
}
```

```tsx
import style from 'index.module.css';

const Component = () => <div className={clsx(style.valid, style.invalid)}></div>
```

It just becomes:

```tsx
const Component = () => <div className={clsx('flex', ` `)}></div>
```